### PR TITLE
Update deploying-from-dockerhub.md

### DIFF
--- a/before-you-start/deploying-from-dockerhub.md
+++ b/before-you-start/deploying-from-dockerhub.md
@@ -31,4 +31,13 @@ What is even more interesting: you can get a shell in the container (after launc
 $ docker exec -it container_id env TERM=xterm /bin/bash
 ```
 
+If you're running the container on Windows through Docker Quickstart Terminal and Oracle VirtualBox, additional steps need to be taken to access the dashboard from your Windows machine. First, you then want to go into the settings for the virtual machine through the VirtualBox manager. To accomplish this, click on your VM, and click on 'Settings'. Now go to the 'Network' tab and you should see two adapters, we want to reconfigure adapter 1. Change the 'Attached to' setting to 'Bridged Adapter', open up the Advanced dropdown, and change the Promiscuous Mode to 'Allow VMs'. Now change Bridged Adapter to NAT and click on Port Forwarding. Here you need to set up a rule that allows port 5601 on the VM to talk to localhost:5601 on your host machine. To do this, click the green diamond with a '+' inside it to add a new rule. Name this rule whatever you wish, set its protocol to TCP, host IP to 127.0.0.1, Host Port to 5601, leave Guest IP blank, and set Guest Port to 5601 and click OK. While you're in settings, I recommend upping the memory for your VM to 2048MB, and setting display memory to 10MB. After you've done this you can now exit all the way out of settings. You now need to stop the docker container if it's currently running, shut down your VM, and restart your VM. Once the VM is restarted, you'll need to run ``ifconfig | grep inet`` on the virtual machine the container is running on to find its local IP address, most likely it will be along the lines of 10.0.2.x. Now rerun 
+
+```bash
+$ docker run -p x.x.x.x:5601:5601 \
+    -v $(pwd)/credentials.cfg:/mordred-override.cfg \
+    -t grimoirelab/full
+```
+but replace the x'ed out IP address with the IP address of your VM that you got from `ifconfig`. If all goes well, once you see the docker command line print out "Elasticsearch Aliased: Created!", you should be able to go to 127.0.0.1:5601 on your host machine web browser and be able to access the GrimoireLab dashboard.
+
 The container allows for much more: you can configure the project you want to analyze, have access to the logging created while producing the dashboard, etc. And there are some more ready-to-use container images that could be useful to you. Have a look at the section [Mordred in a container](../mordred/mordred-in-a-container.md) to learn about how to produce dashboards in different ways, and run arbitrary GrimoireLab code, from these containers. More details about the docker images produced by the GrimoireLab projects are available in the [docker/README.md file in the grimoirelab GitHub repository](https://github.com/chaoss/grimoirelab/blob/master/docker/README.md).


### PR DESCRIPTION
Adding instructions for Windows Docker users to be able to correctly configure and run the VM/container to be able to access the GrimoireLab dashboard from the host machine.